### PR TITLE
fix: change dashboard after exit full screen, dashboard became white screen or wrong style

### DIFF
--- a/webapp/app/containers/Dashboard/components/fullScreenPanel/FullScreenPanel.tsx
+++ b/webapp/app/containers/Dashboard/components/fullScreenPanel/FullScreenPanel.tsx
@@ -135,6 +135,8 @@ class FullScreenPanel extends React.PureComponent<IFullScreenPanelProps, IFullSc
       const c = currentDataInFullScreen
       title = c.widget.name
       itemInfo = currentItemsInfo[c.itemId]
+      // fix: 修复切换dashboard后，itemInfo为undefined, 导致的白屏或展示异常问题
+      if (!itemInfo) return null
       const widgetProps = JSON.parse(currentDataInFullScreen.widget.config)
       const queryVariables = this.getQueryVariables(itemInfo.queryConditions)
       charts = (


### PR DESCRIPTION
change dashboard after exit full screen, currentItemsInfo is change, bu c.itemid is last itemid, so itemInfo undefined cause dashboard became white screen or wrong style.

在一个dashboard中全屏一个widget，退出全屏后，切换dashboard，currentItemsInfo 变化了，但是 c.itemid 还是之前的 itemid，所以 itemInfo 变成了 undefined，仪表盘展示异常或者白屏。

![image](https://user-images.githubusercontent.com/7961364/67542354-09aeac80-f71f-11e9-8af9-218c0fa16fe5.png)
