### PR TITLE
Fix: Sort order not display as expected when bar chart stacked #1440

### DIFF
--- a/webapp/app/containers/Widget/components/Config/Sort/util.ts
+++ b/webapp/app/containers/Widget/components/Config/Sort/util.ts
@@ -18,7 +18,7 @@ export function fieldGroupedSort (data: object[], descriptors: IFieldSortDescrip
   })
 }
 
-export function colorSort (
+export function inGroupColorSort (
   groupEntries: Array<[string, unknown]>,
   descriptor: IFieldSortDescriptor
 ) {

--- a/webapp/app/containers/Widget/components/Widget/index.tsx
+++ b/webapp/app/containers/Widget/components/Widget/index.tsx
@@ -58,6 +58,7 @@ export interface IWidgetMetric {
   chart: IChartInfo
   field: IFieldConfig
   format: IFieldFormatConfig
+  sort?: IFieldSortConfig
 }
 
 export interface IWidgetSecondaryMetric {
@@ -65,6 +66,7 @@ export interface IWidgetSecondaryMetric {
   agg: AggregatorType
   field: IFieldConfig
   format: IFieldFormatConfig
+  sort?: IFieldSortConfig
   from?: string
   type?: any
   visualType?: any

--- a/webapp/app/containers/Widget/render/chart/area.ts
+++ b/webapp/app/containers/Widget/render/chart/area.ts
@@ -82,7 +82,7 @@ export default function (dataSource, flatInfo, chartParams) {
   let xAxisDistincted = []
 
   if (hasGroups && groups && groups.length) {
-    xAxisDistincted = distinctXaxis(dataSource, xAxis)
+    xAxisDistincted = getGroupedXaxis(dataSource, xAxis)
     grouped = makeGrouped(dataSource, [].concat(groups).filter((i) => !!i), xAxis, metrics, xAxisDistincted)
   }
 
@@ -290,7 +290,7 @@ export function makeGrouped (dataSource, groupColumns, xAxis, metrics, xAxisDist
   return grouped
 }
 
-export function distinctXaxis (dataSource, xAxis) {
+export function getGroupedXaxis (dataSource, xAxis) {
   return xAxis
     ? Object.keys(dataSource.reduce((distinct, ds) => {
       if (!distinct[ds[xAxis]]) {

--- a/webapp/app/containers/Widget/render/chart/bar.ts
+++ b/webapp/app/containers/Widget/render/chart/bar.ts
@@ -36,7 +36,7 @@ import {
   getLegendOption,
   getGridPositions,
   makeGrouped,
-  distinctXaxis,
+  getGroupedXaxis,
   getCartesianChartMetrics
 } from './util'
 import { getStackName, EmptyStack } from 'containers/Widget/components/Config/Stack'
@@ -44,7 +44,7 @@ const defaultTheme = require('assets/json/echartsThemes/default.project.json')
 const defaultThemeColors = defaultTheme.theme.color
 
 import { barChartStylesMigrationRecorder } from 'utils/migrationRecorders'
-import { colorSort } from '../../components/Config/Sort/util'
+import { inGroupColorSort } from '../../components/Config/Sort/util'
 import { FieldSortTypes } from '../../components/Config/Sort'
 
 export default function (chartProps: IChartProps, drillOptions) {
@@ -107,11 +107,12 @@ export default function (chartProps: IChartProps, drillOptions) {
 
   const xAxisColumnName = cols.length ? cols[0].name : ''
 
-  let xAxisData = data.map((d) => d[xAxisColumnName] || '')
+  let xAxisData = []
   let grouped = {}
   let percentGrouped = {}
+
   if (color.items.length) {
-    xAxisData = distinctXaxis(data, xAxisColumnName)
+    xAxisData = getGroupedXaxis(data, xAxisColumnName, metrics)
     grouped = makeGrouped(
       data,
       color.items.map((c) => c.name),
@@ -132,6 +133,8 @@ export default function (chartProps: IChartProps, drillOptions) {
       metrics,
       configKeys
     )
+  } else {
+    xAxisData = data.map((d) => d[xAxisColumnName] || '')
   }
 
   const series = []
@@ -152,7 +155,7 @@ export default function (chartProps: IChartProps, drillOptions) {
         .filter(({ sort }) => sort && sort.sortType === FieldSortTypes.Custom)
         .map(({ name, sort }) => ({ name, list: sort[FieldSortTypes.Custom].sortList }))
       if (customColorSort.length) {
-        colorSort(groupEntries, customColorSort[0])
+        inGroupColorSort(groupEntries, customColorSort[0])
       }
 
       groupEntries.forEach(([k, v]: [string, any[]]) => {

--- a/webapp/app/containers/Widget/render/chart/line.ts
+++ b/webapp/app/containers/Widget/render/chart/line.ts
@@ -31,7 +31,7 @@ import {
   getLegendOption,
   getGridPositions,
   makeGrouped,
-  distinctXaxis,
+  getGroupedXaxis,
   getCartesianChartMetrics
 } from './util'
 import { getFormattedValue } from '../../components/Config/Format'
@@ -63,10 +63,11 @@ export default function (chartProps: IChartProps, drillOptions?: any) {
   }
 
   const xAxisColumnName = cols[0].name
-  let xAxisData = data.map((d) => d[xAxisColumnName] || '')
+  let xAxisData = []
   let grouped = {}
+
   if (color.items.length) {
-    xAxisData = distinctXaxis(data, xAxisColumnName)
+    xAxisData = getGroupedXaxis(data, xAxisColumnName, metrics)
     grouped = makeGrouped(
       data,
       color.items.map((c) => c.name),
@@ -74,6 +75,8 @@ export default function (chartProps: IChartProps, drillOptions?: any) {
       metrics,
       xAxisData
     )
+  } else {
+    xAxisData = data.map((d) => d[xAxisColumnName] || '')
   }
 
   const series = []

--- a/webapp/app/containers/Widget/render/chart/waterfall.ts
+++ b/webapp/app/containers/Widget/render/chart/waterfall.ts
@@ -29,9 +29,7 @@ import {
   getMetricAxisOption,
   getLabelOption,
   getLegendOption,
-  getGridPositions,
-  makeGrouped,
-  distinctXaxis
+  getGridPositions
 } from './util'
 import { EChartOption } from 'echarts'
 import { getFormattedValue } from '../../components/Config/Format'


### PR DESCRIPTION
#1440 
This may be a temporary fix.
Remaining problem: in color grouping situation, metric sorting will have priority over custom sorting.