### PR TITLE
Update OperatingPanel.tsx

### DIFF
--- a/webapp/app/containers/Widget/components/Workbench/OperatingPanel.tsx
+++ b/webapp/app/containers/Widget/components/Workbench/OperatingPanel.tsx
@@ -5,7 +5,7 @@ import set from 'lodash/set'
 import widgetlibs from '../../config'
 import { IDataRequestParams } from 'app/containers/Dashboard/types'
 import { IViewBase, IFormedView } from 'containers/View/types'
-import { ViewModelVisualTypes } from 'containers/View/constants'
+import { ViewModelVisualTypes, ViewModelTypes } from 'containers/View/constants'
 import Dropbox, { DropboxType, DropType, AggregatorType, IDataParamSource, IDataParamConfig, DragType, IDragItem} from './Dropbox'
 import { IWidgetProps, IChartStyles, IChartInfo, IPaginationParams, WidgetMode, RenderType, DimetionType } from '../Widget'
 import { IFieldConfig, getDefaultFieldConfig, FieldConfigModal } from '../Config/Field'
@@ -232,7 +232,9 @@ export class OperatingPanel extends React.Component<IOperatingPanelProps, IOpera
       const { dataParams } = this.state
       const model = selectedView.model
       const currentWidgetlibs = widgetlibs[mode || 'pivot'] // FIXME 兼容 0.3.0-beta.1 之前版本
-
+      if (mode === 'pivot') {
+        model['指标名称']   = ({sqlType: 'VARCHAR', visualType: ViewModelVisualTypes.String, modelType: ViewModelTypes.Category})
+      }
       cols.forEach((c) => {
         const modelColumn = model[c.name]
         if (modelColumn) {


### PR DESCRIPTION
bug 描述：编辑Widget，透视驱动模式下，指标名称不能回显（数据库其实保存成功了，但是修改时候，这个维度不能回显）
修复图表透视下table 编辑，指标名称不能回显bug
![image](https://user-images.githubusercontent.com/15976650/79468440-7f8e3380-8031-11ea-8cb6-7a09b0525699.png)
