### PR TITLE
fix: ConditionValuesControl  Fallthrough case

### DIFF
--- a/webapp/app/components/ConditionValuesControl/index.tsx
+++ b/webapp/app/components/ConditionValuesControl/index.tsx
@@ -70,6 +70,7 @@ export class ConditionValuesControl extends React.PureComponent<IConditionValues
         break
       case OperatorTypes.Between:
         valuesCount = 2
+        break
       case OperatorTypes.In:
         valuesCount = conditionValues.length
         break


### PR DESCRIPTION
ConditionValuesControl  Fallthrough case in switch