### PR TITLE
fix: submit share download can not be Certified

### DIFF
--- a/server/src/main/java/edp/davinci/controller/DownloadController.java
+++ b/server/src/main/java/edp/davinci/controller/DownloadController.java
@@ -131,6 +131,7 @@ public class DownloadController extends BaseController {
                                                   @RequestParam(required = false) String password,
                                                   @PathVariable(name = "uuid") String uuid,
                                                   @PathVariable(name = "type") String type,
+                                                  @ApiIgnore @CurrentUser User user,
                                                   @Valid @RequestBody(required = false) DownloadViewExecuteParam[] params) {
 
         List<DownloadViewExecuteParam> downloadViewExecuteParams = Arrays.asList(params);


### PR DESCRIPTION
fix: submit share download can not be Certified （#2034）