### PR TITLE
Unset server.address to fix docker port error.

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -17,7 +17,7 @@
 
 server:
   protocol: http
-  address: 127.0.0.1
+  address:
   port: 8080
 
   servlet:


### PR DESCRIPTION
Unset server.address to fix docker port error.

https://github.com/edp963/davinci/issues/1957
https://github.com/edp963/davinci-docker/issues/30
