### PR TITLE
feature: share page supports OAuth2 authentication

### DIFF
--- a/webapp/share/components/ExternalLogin/ExternalLogin.less
+++ b/webapp/share/components/ExternalLogin/ExternalLogin.less
@@ -1,0 +1,14 @@
+.externalauth {
+  a {
+    display: block;
+    width: 240px;
+    height: 36px;
+    margin-top: 10px;
+    line-height: 36px;
+    text-align:center;
+    border: 1px solid  #fff;
+    border-radius: 3px;
+    color:#fff;
+    font-weight: bold;
+  }
+}

--- a/webapp/share/components/ExternalLogin/index.tsx
+++ b/webapp/share/components/ExternalLogin/index.tsx
@@ -2,31 +2,21 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { compose } from 'redux'
 import { createStructuredSelector } from 'reselect'
-import { getExternalAuthProviders, tryExternalAuth } from '../App/actions'
-import { makeSelectExternalAuthProviders } from '../App/selectors'
+import { getExternalAuthProviders } from 'share/containers/App/actions'
+import { makeSelectExternalAuthProviders } from 'share/containers/App/selectors'
 const styles = require('./ExternalLogin.less')
 
 
 interface IExternalLoginProps {
   providers: Array<{}>
   onGetExternalAuthProviders: () => any
-  tryExternalAuth: (resolve: () => any) => any
 }
 
 class ExternalLogin extends React.Component<IExternalLoginProps, {}> {
 
   public componentWillMount() {
-    const { onGetExternalAuthProviders, tryExternalAuth } = this.props
+    const { onGetExternalAuthProviders } = this.props
     onGetExternalAuthProviders()
-    tryExternalAuth(() => {
-      if(localStorage.getItem('shareToken')) {
-        const token = localStorage.getItem('shareToken')
-        const hash = localStorage.getItem('shareRoute')
-        location.replace(`/share.html?shareToken=${token}${hash}`)
-        return
-      }
-      location.replace('/#/projects')
-    })
   }
 
   private mapProviders = (authProviders) => {
@@ -59,7 +49,6 @@ class ExternalLogin extends React.Component<IExternalLoginProps, {}> {
 export function mapDispatchToProps(dispatch) {
   return {
     onGetExternalAuthProviders: () => dispatch(getExternalAuthProviders()),
-    tryExternalAuth: (resolve) => dispatch(tryExternalAuth(resolve))
   }
 }
 

--- a/webapp/share/components/Login/index.tsx
+++ b/webapp/share/components/Login/index.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, FormEvent } from 'react'
 import { connect } from 'react-redux'
 import LoginForm from 'app/containers/Login/LoginForm'
+import ExternalLogin from 'share/components/ExternalLogin'
 import Background from 'share/components/Background'
 import { AppActions } from 'share/containers/App/actions'
 import checkLogin from 'utils/checkLogin'
@@ -9,6 +10,7 @@ import { message } from 'antd'
 interface ILoginProps {
   loading: boolean
   shareToken: any
+  oauth2Enabled: boolean
   loginCallback?: () => void
   onLogin?: (
     username: string,
@@ -86,7 +88,7 @@ class Login extends React.PureComponent<ILoginProps, ILoginStates> {
   }
 
   public render() {
-    const { loading } = this.props
+    const { loading, oauth2Enabled } = this.props
     const { username, password } = this.state
     return (
       <Background>
@@ -98,6 +100,7 @@ class Login extends React.PureComponent<ILoginProps, ILoginStates> {
           onChangePassword={this.changePassword}
           onLogin={this.doLogin}
         />
+        {oauth2Enabled && <ExternalLogin />}
       </Background>
     )
   }

--- a/webapp/share/containers/App/Interceptor.tsx
+++ b/webapp/share/containers/App/Interceptor.tsx
@@ -24,7 +24,12 @@ import { useInjectReducer } from 'utils/injectReducer'
 import { useInjectSaga } from 'utils/injectSaga'
 import { ActionTypes } from './constants'
 import { AppActions } from './actions'
-import { makeSelectShareType, makeSelectPermissionLoading } from './selectors'
+import {
+  makeSelectShareType,
+  makeSelectPermissionLoading,
+  makeSelectLoginLoading,
+  makeSelectOauth2Enabled
+} from './selectors'
 import Password from 'share/components/Password'
 import Login from 'share/components/Login'
 import {
@@ -38,7 +43,6 @@ import reducer from './reducer'
 import saga from './sagas'
 import { Tmode } from 'app/components/SharePanel/types'
 import { message } from 'antd'
-import { makeSelectLoginLoading } from '../App/selectors'
 
 const Interceptor: React.FC<any> = (props) => {
   useInjectReducer({ key: 'global', reducer })
@@ -47,6 +51,7 @@ const Interceptor: React.FC<any> = (props) => {
   const shareType: Tmode = useSelector(makeSelectShareType())
   const loading: boolean = useSelector(makeSelectPermissionLoading())
   const loginLoading: boolean = useSelector(makeSelectLoginLoading())
+  const oauth2Enabled: boolean = useSelector(makeSelectOauth2Enabled())
 
   const { shareToken } = useMemo(
     () => querystring(window.location.search.substr(1)),
@@ -88,6 +93,8 @@ const Interceptor: React.FC<any> = (props) => {
   )
 
   const afterLogin = useCallback(() => {
+    localStorage.removeItem('shareToken')
+    localStorage.removeItem('shareRoute')
     setLegitimate(true)
     dispatch(AppActions.getPermissions(shareToken))
   }, [islegitimate])
@@ -100,6 +107,7 @@ const Interceptor: React.FC<any> = (props) => {
       if (shareType === 'AUTH' && !islegitimate) {
         return (
           <Login
+            oauth2Enabled={oauth2Enabled}
             loading={loginLoading}
             shareToken={shareToken}
             loginCallback={afterLogin}

--- a/webapp/share/containers/App/actions.ts
+++ b/webapp/share/containers/App/actions.ts
@@ -22,6 +22,21 @@ import { ActionTypes } from './constants'
 import { returnType } from 'utils/redux'
 import { IServerConfigurations } from 'app/containers/App/types'
 
+export function getExternalAuthProviders() {
+  return {
+    type: ActionTypes.GET_EXTERNAL_AUTH_PROVIDERS
+  }
+}
+
+export function gotExternalAuthProviders(externalAuthProviders) {
+  return {
+    type: ActionTypes.GET_EXTERNAL_AUTH_PROVIDERS_SUCESS,
+    payload: {
+      externalAuthProviders
+    }
+  }
+}
+
 export const AppActions = {
   login(username, password, shareToken, resolve, reject?) {
     return {

--- a/webapp/share/containers/App/constants.ts
+++ b/webapp/share/containers/App/constants.ts
@@ -22,6 +22,8 @@ import { createTypes } from 'app/utils/redux'
 
 enum Types {
   DEFAULT_LOCALE = 'en',
+  GET_EXTERNAL_AUTH_PROVIDERS = 'davinci/App/GET_EXTERNAL_AUTH_PROVIDERS',
+  GET_EXTERNAL_AUTH_PROVIDERS_SUCESS = 'davinci/App/GET_EXTERNAL_AUTH_PROVIDERS_SUCESS',
   LOGIN = 'davinci/Share/App/LOGIN',
   LOGGED = 'davinci/Share/App/LOGGED',
   LOGON_FAILURE = 'davinci/Share/App/LOGON_FAILURE',

--- a/webapp/share/containers/App/index.tsx
+++ b/webapp/share/containers/App/index.tsx
@@ -57,6 +57,8 @@ export const App: React.FC = () => {
   const dispatch = useDispatch()
 
   useEffect(() => {
+    localStorage.setItem('shareToken', shareToken)
+    localStorage.setItem('shareRoute', window.location.hash)
     dispatch(AppActions.interceptor(shareToken))
     dispatch(AppActions.getServerConfigurations())
   }, [])
@@ -76,6 +78,8 @@ export const App: React.FC = () => {
 
   useEffect(() => {
     if (shareType === 'NORMAL') {
+      localStorage.removeItem('shareToken')
+      localStorage.removeItem('shareRoute')
       dispatch(AppActions.getPermissions(shareToken))
     }
   }, [shareType])

--- a/webapp/share/containers/App/reducer.ts
+++ b/webapp/share/containers/App/reducer.ts
@@ -30,6 +30,8 @@ interface IState {
   vizType: 'dashboard' | 'widget' | 'display' | ''
   permissionLoading: boolean
   download: boolean
+  oauth2Enabled: boolean
+  externalAuthProviders: any[]
 }
 
 export const initialState: IState = {
@@ -39,12 +41,17 @@ export const initialState: IState = {
   shareType: '',
   vizType: '',
   permissionLoading: false,
-  download: false
+  download: false,
+  oauth2Enabled: false,
+  externalAuthProviders: []
 }
 
 const appReducer = (state = initialState, action) =>
   produce(state, (draft) => {
     switch (action.type) {
+      case ActionTypes.GET_EXTERNAL_AUTH_PROVIDERS_SUCESS:
+        draft.externalAuthProviders = action.payload.externalAuthProviders
+        break
       case ActionTypes.LOGIN:
         draft.loading = true
         break
@@ -59,6 +66,10 @@ const appReducer = (state = initialState, action) =>
       case ActionTypes.LOGOUT:
         draft.logged = false
         draft.loginUser = null
+        break
+      case ActionTypes.GET_SERVER_CONFIGURATIONS_SUCCESS:
+        draft.oauth2Enabled =
+          action.payload.configurations.security.oauth2.enable
         break
       case ActionTypes.INTERCEPTOR_PREFLIGHT_SUCCESS:
         draft.shareType = action.payload.shareType

--- a/webapp/share/containers/App/sagas.ts
+++ b/webapp/share/containers/App/sagas.ts
@@ -21,12 +21,26 @@
 import { call, put, all, takeLatest, takeEvery } from 'redux-saga/effects'
 
 import { ActionTypes } from './constants'
-import { AppActions, AppActionType } from './actions'
+import { AppActions, AppActionType, gotExternalAuthProviders } from './actions'
 
 import request, { IDavinciResponse, setTokenExpired } from 'utils/request'
 import { errorHandler } from 'utils/util'
 import { IServerConfigurations } from 'app/containers/App/types'
 import api from 'utils/api'
+
+export function* getExternalAuthProviders() {
+  try {
+    const asyncData = yield call(request, {
+      method: 'get',
+      url: api.externalAuthProviders
+    })
+    const providers = asyncData.payload
+    yield put(gotExternalAuthProviders(providers))
+    return providers
+  } catch (err) {
+    errorHandler(err)
+  }
+}
 
 export function* login(action: AppActionType) {
   if (action.type !== ActionTypes.LOGIN) {
@@ -126,6 +140,7 @@ export function* getServerConfigurations(action: AppActionType) {
 
 export default function* rootAppSaga() {
   yield all([
+    takeLatest(ActionTypes.GET_EXTERNAL_AUTH_PROVIDERS, getExternalAuthProviders),
     takeLatest(ActionTypes.LOGIN, login),
     takeEvery(ActionTypes.INTERCEPTOR_PREFLIGHT, interceptor),
     takeEvery(ActionTypes.GET_PERMISSIONS, getPermissions),

--- a/webapp/share/containers/App/selectors.ts
+++ b/webapp/share/containers/App/selectors.ts
@@ -66,7 +66,17 @@ const makeSelectPermissionLoading = () => createSelector(
   }
 )
 
+const makeSelectExternalAuthProviders = () =>
+  createSelector(
+    selectGlobal,
+    (globalState) => globalState.externalAuthProviders
+  )
 
+const makeSelectOauth2Enabled = () =>
+  createSelector(
+    selectGlobal,
+    (globalState) => globalState.oauth2Enabled
+  )
 
 
 
@@ -78,5 +88,7 @@ export {
   makeSelectShareType,
   makeSelectVizType,
   makeSelectPermission,
-  makeSelectPermissionLoading
+  makeSelectPermissionLoading,
+  makeSelectExternalAuthProviders,
+  makeSelectOauth2Enabled
 }


### PR DESCRIPTION
Simple jump mode(Only if `shareType` equals `AUTH`): use `localStorage` save `shareToken` and `hash`.
After successful authentication, use the stored values to jump to the share page and delete the values.