### PR TITLE
fix: 🐛 修复view页面执行sql错误

### DIFF
--- a/webapp/app/containers/View/components/SqlPreview.tsx
+++ b/webapp/app/containers/View/components/SqlPreview.tsx
@@ -94,7 +94,7 @@ export class SqlPreview extends React.PureComponent<ISqlPreviewProps, ISqlPrevie
 
   public render () {
     const { loading, response, size } = this.props
-    const { totalCount, columns, resultList } = response
+    const { totalCount, columns = [], resultList =[] } = response
     const paginationConfig: PaginationConfig = {
       ...SqlPreview.basePagination,
       total: totalCount


### PR DESCRIPTION
某些情况下,执行选中sql接口返回response: ""时错误