### PR TITLE
fix: format sql  with different utility functions

### DIFF
--- a/server/src/main/java/edp/core/utils/SqlUtils.java
+++ b/server/src/main/java/edp/core/utils/SqlUtils.java
@@ -1079,9 +1079,18 @@ public class SqlUtils {
         return this.jdbcSourceInfo.getJdbcUrl();
     }
 
-    public static String formatSql(String sql) {
+    public String formatSql(String sql) {
         try {
-            return SQLUtils.formatMySql(sql);
+            switch (dataTypeEnum) {
+                case ORACLE:
+                    return SQLUtils.formatOracle(sql);
+                case MYSQL:
+                    return SQLUtils.formatMySql(sql);
+                case HIVE2:
+                    return SQLUtils.formatHive(sql);
+                default:
+                    return sql;
+            }
         } catch (Exception e) {
             // ignore
         }

--- a/server/src/main/java/edp/davinci/service/excel/SheetWorker.java
+++ b/server/src/main/java/edp/davinci/service/excel/SheetWorker.java
@@ -89,7 +89,7 @@ public class SheetWorker<T> extends AbstractSheetWriter implements Callable {
             Set<String> queryFromsAndJoins = SqlUtils.getQueryFromsAndJoins(sql);
             if (log) {
                 logger.info("Task({}) sheet worker(name:{}, sheetNo:{}, sheetName:{}) query start sql:{}, md5:{}",
-                        context.getTaskKey(), context.getName(), context.getSheetNo(), context.getSheet().getSheetName(), SqlUtils.formatSql(sql), md5);
+                        context.getTaskKey(), context.getName(), context.getSheetNo(), context.getSheet().getSheetName(), utils.formatSql(sql), md5);
             }
 
             final AtomicInteger count = new AtomicInteger(0);


### PR DESCRIPTION
format sql with different data type with different uitlity functions 
to avoid throwing exceptions while using different sources. e.g. Oracle