### PR TITLE
fix: 修复table多选之后无法取消选中的问题

### DIFF
--- a/webapp/app/containers/Widget/components/Chart/Table/index.tsx
+++ b/webapp/app/containers/Widget/components/Chart/Table/index.tsx
@@ -448,10 +448,7 @@ export class Table extends React.PureComponent<IChartProps, ITableStates> {
       columns,
       nativeIndex
     )
-    return array.filter(
-      (arr) =>
-        arr['index'] < array[start]['index'] || arr.index > array[end]['index']
-    )
+    return array.filter((_, index) => index < start || index > end);
   }
 
   private collectCell = (target, index, dataIndex: string) => (event) => {


### PR DESCRIPTION
问题：
table列 从下往上选中单元格，之后无法正常进行取消选中操作