### PR TITLE
fix: ODPS dbType

### DIFF
--- a/server/src/main/java/edp/core/common/jdbc/JdbcDataSource.java
+++ b/server/src/main/java/edp/core/common/jdbc/JdbcDataSource.java
@@ -315,15 +315,7 @@ public class JdbcDataSource {
             }
 
             // druid wall filter not support some database so set type mysql
-            if (DataTypeEnum.MOONBOX == DataTypeEnum.urlOf(jdbcUrl) ||
-                    DataTypeEnum.MONGODB == DataTypeEnum.urlOf(jdbcUrl) ||
-                    DataTypeEnum.ELASTICSEARCH == DataTypeEnum.urlOf(jdbcUrl) ||
-                    DataTypeEnum.CASSANDRA == DataTypeEnum.urlOf(jdbcUrl) ||
-                    DataTypeEnum.VERTICA == DataTypeEnum.urlOf(jdbcUrl) ||
-                    DataTypeEnum.KYLIN == DataTypeEnum.urlOf(jdbcUrl) ||
-                    DataTypeEnum.HANA == DataTypeEnum.urlOf(jdbcUrl) ||
-                    DataTypeEnum.IMPALA == DataTypeEnum.urlOf(jdbcUrl) ||
-                    DataTypeEnum.TDENGINE == DataTypeEnum.urlOf(jdbcUrl)) {
+            if (DataTypeEnum.hasMysqlFeature(jdbcUrl)) {
                 wallFilter.setDbType(DataTypeEnum.MYSQL.getFeature());
             }
 

--- a/server/src/main/java/edp/core/enums/DataTypeEnum.java
+++ b/server/src/main/java/edp/core/enums/DataTypeEnum.java
@@ -22,6 +22,9 @@ package edp.core.enums;
 import edp.core.consts.Consts;
 import edp.core.exception.SourceException;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 public enum DataTypeEnum {
 
     MYSQL("mysql", "mysql", "com.mysql.cj.jdbc.Driver", "`", "`", "'", "'"),
@@ -56,7 +59,9 @@ public enum DataTypeEnum {
 
     IMPALA("impala", "impala", "com.cloudera.impala.jdbc41.Driver", "", "", "'", "'"),
 
-    TDENGINE("TAOS", "TAOS", "com.taosdata.jdbc.TSDBDriver", "'", "'", "\"", "\"");
+    TDENGINE("TAOS", "TAOS", "com.taosdata.jdbc.TSDBDriver", "'", "'", "\"", "\""),
+
+    ODPS("odps", "odps", "com.aliyun.odps.jdbc.OdpsDriver", "", "", "`", "`");
 
     private String feature;
     private String desc;
@@ -76,6 +81,9 @@ public enum DataTypeEnum {
         this.aliasSuffix = aliasSuffix;
     }
 
+    private static Set<DataTypeEnum> mysqlTypeDBs = EnumSet.of(MOONBOX, MONGODB, ELASTICSEARCH,
+            CASSANDRA, VERTICA, KYLIN, HANA, IMPALA, TDENGINE, ODPS);
+
     public static DataTypeEnum urlOf(String jdbcUrl) throws SourceException {
         String url = jdbcUrl.toLowerCase().trim();
         for (DataTypeEnum dataTypeEnum : values()) {
@@ -84,6 +92,14 @@ public enum DataTypeEnum {
             }
         }
         return null;
+    }
+
+    public static boolean hasMysqlFeature(String jdbcUrl) throws SourceException {
+        DataTypeEnum dataTypeEnum = urlOf(jdbcUrl);
+        if (dataTypeEnum != null && mysqlTypeDBs.contains(dataTypeEnum)) {
+            return true;
+        }
+        return false;
     }
 
     public String getFeature() {


### PR DESCRIPTION
When I using [ODPS](https://help.aliyun.com/document_detail/280394.html) datasource in latest (branch dev-0.3) Exception thrown.

the reason is `druid wall filter not support some database` so I do these :
1. add ODPS to DataTypeEnum
2. refactor `if condition` 
    - DataTypeEnum.urlOf call many times if left condition not match.
    - put them to EnumSet help performance.

hope merge

log is here
```log
2022-01-20 11:41:48.067 ERROR 23567 --- [0.1-8080-exec-4] com.alibaba.druid.pool.DruidDataSource   : {dataSource-2} init error

java.lang.IllegalStateException: dbType not support : odps, url jdbc:odps:http://service.cn-beijing.maxcompute.aliyun.com/api?project=xxxx
	at com.alibaba.druid.wall.WallFilter.init(WallFilter.java:192)
	at com.alibaba.druid.pool.DruidDataSource.init(DruidDataSource.java:829)
	at edp.core.common.jdbc.JdbcDataSource.getDataSource(JdbcDataSource.java:373)
	at edp.core.utils.SourceUtils.getDataSource(SourceUtils.java:92)
	at edp.core.utils.SourceUtils.getConnectionWithRetry(SourceUtils.java:119)
	at edp.core.utils.SourceUtils.getConnection(SourceUtils.java:96)
	at edp.core.utils.SqlUtils.getDatabases(SqlUtils.java:425)
	at edp.davinci.service.impl.SourceServiceImpl.getSourceDbs(SourceServiceImpl.java:539)
	at edp.davinci.service.impl.SourceServiceImpl$$FastClassBySpringCGLIB$$88b19aec.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:204)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:684)
	at edp.davinci.service.impl.SourceServiceImpl$$EnhancerBySpringCGLIB$$183a58bf.getSourceDbs(<generated>)
	at edp.davinci.controller.SourceController.getSourceDbs(SourceController.java:323)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:209)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:136)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:102)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:877)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:783)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:991)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:925)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:974)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:866)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:635)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:851)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:742)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at com.alibaba.druid.support.http.WebStatFilter.doFilter(WebStatFilter.java:124)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:200)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:198)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:493)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:140)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:800)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:800)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1471)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:748)
```